### PR TITLE
✨ feat(query_adapter): add custom SqlParseException for invalid SQL s…

### DIFF
--- a/froom_common/lib/src/adapter/query_adapter.dart
+++ b/froom_common/lib/src/adapter/query_adapter.dart
@@ -5,6 +5,7 @@ import 'package:sqflite_common/sqlite_api.dart';
 import 'package:sqlparser/sqlparser.dart';
 
 import '../util/constants.dart';
+import '../util/exceptions.dart';
 
 /// This class knows how to execute database queries.
 class QueryAdapter {
@@ -148,6 +149,10 @@ class QueryAdapter {
     } else if (rootNode is DeleteStatement) {
       result = await _database.rawDelete(sql, arguments).then(_mapResult);
       tableName = rootNode.table.tableName;
+    } else if (rootNode is InvalidStatement) {
+      throw SqlParseException(sql);
+    } else {
+      throw StateError('Unknown statement type: $rootNode');
     }
 
     _notifyIfChanged(tableName, result);

--- a/froom_common/lib/src/util/exceptions.dart
+++ b/froom_common/lib/src/util/exceptions.dart
@@ -1,0 +1,11 @@
+/// Exception thrown when SQL parsing fails.
+class SqlParseException implements Exception {
+  /// The SQL query that failed to parse.
+  final String sql;
+
+  /// Creates a new SQL parse exception with the given SQL query.
+  const SqlParseException(this.sql);
+
+  @override
+  String toString() => 'Failed to parse "$sql"';
+}

--- a/froom_common/test/adapter/query_adapter_test.dart
+++ b/froom_common/test/adapter/query_adapter_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:froom_common/src/adapter/query_adapter.dart';
+import 'package:froom_common/src/util/exceptions.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -22,6 +23,12 @@ void main() {
 
   group('queries (no stream)', () {
     final underTest = QueryAdapter(mockDatabaseExecutor);
+
+    test('exception because query can not be parsed', () async {
+      final deleteQueryFuture = underTest.queryNoReturn('DELETE * FROM foo');
+
+      expect(deleteQueryFuture, throwsA(isA<SqlParseException>()));
+    });
 
     group('query item', () {
       test('returns item without arguments', () async {


### PR DESCRIPTION
Fix https://github.com/pinchbv/floor/issues/820

- Add SqlParseException class in froom_common/lib/src/util/exceptions.dart
- Update QueryAdapter to throw SqlParseException for InvalidStatement cases
- Add test case to verify exception is thrown for invalid SQL like "DELETE * FROM foo"
- Improve error handling with specific exception type instead of generic Exception