### PR TITLE
Accept backtick-quoted table names for queryableName

### DIFF
--- a/froom_generator/lib/writer/query_method_writer.dart
+++ b/froom_generator/lib/writer/query_method_writer.dart
@@ -239,7 +239,7 @@ class QueryMethodWriter implements Writer {
   }
 
   String _parseTableName(String query) {
-    return RegExp(r'(?<=FROM )\w+', caseSensitive: false)
+    return RegExp(r'(?<=FROM `?)\w+(?=`?)', caseSensitive: false)
             .firstMatch(query)
             ?.group(0) ??
         'no_table_name';

--- a/froom_generator/test/writer/query_method_writer_test.dart
+++ b/froom_generator/test/writer/query_method_writer_test.dart
@@ -691,6 +691,22 @@ void main() {
     '''));
   });
 
+  test('query with backtick-quoted table name', () async {
+    final queryMethod = await _createQueryMethod('''
+      @Query('SELECT id FROM `Person`')
+      Stream<List<int>> getPeopleIdListAsStream();
+    ''');
+
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Stream<List<int>> getPeopleIdListAsStream() {
+        return _queryAdapter.queryListStream('SELECT id FROM `Person`', mapper: (Map<String, Object?> row) => row.values.first as int, queryableName: 'Person', isView: false);
+      }
+    '''));
+  });
+
   test('Query with IN clause', () async {
     final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id IN (:ids)')


### PR DESCRIPTION
Fixes #160 